### PR TITLE
Support for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ Responds with the basic settings of the router.
 ```
 
 ## Tests
-  npm test
+  HUAWEI_GW_IP=192.168.8.1 HUAWEI_GW_PASSWORD=abc123 npm test
+
+You most likely need to set your device IP and he admin password on the command-line like in the example.
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code.

--- a/lib/router.js
+++ b/lib/router.js
@@ -57,7 +57,7 @@ API.getCurrentPLMN = function(token, callback) {
 
 API.getToken = function(callback) {
   var uri = url('http://', this.options.gateway, '/api/webserver/SesTokInfo');
-  utilities.contactRouter(uri, function(error, response) {
+  utilities.contactRouter(uri, {}, function(error, response) {
     callback(error, {
       cookies: response.SesInfo[0],
       token: response.TokInfo[0]

--- a/lib/router.js
+++ b/lib/router.js
@@ -2,15 +2,15 @@ var utilities = require('./utilities');
 var url = require('url-join');
 require('default');
 
-function DailogRouter(options) {
+function HuaweiRouter(options) {
   this.options = {
     gateway: process.env.HUAWEI_GW_IP || '192.168.8.1'
   };
   this.options = this.options.default(options);
 }
 
-var API = DailogRouter.prototype;
-module.exports = DailogRouter;
+var API = HuaweiRouter.prototype;
+module.exports = HuaweiRouter;
 module.exports.create = create;
 
 API.getMonthStatistics = function(token, callback) {
@@ -66,5 +66,5 @@ API.getToken = function(callback) {
 };
 
 function create(options) {
-  return new DailogRouter(options);
+  return new HuaweiRouter(options);
 }

--- a/lib/router.js
+++ b/lib/router.js
@@ -15,49 +15,49 @@ module.exports.create = create;
 
 API.getMonthStatistics = function(token, callback) {
   var uri = url('http://', this.options.gateway, '/api/monitoring/month_statistics');
-  utilities.contactRouter(uri, token, function(error, response) {
+  utilities.contactRouter(uri, token, null, function(error, response) {
     callback(error, response);
   });
 };
 
 API.getSignal = function(token, callback) {
   var uri = url('http://', this.options.gateway, '/api/device/signal');
-  utilities.contactRouter(uri, token, function(error, response) {
+  utilities.contactRouter(uri, token, null, function(error, response) {
     callback(error, response);
   });
 };
 
 API.getStatus = function(token, callback) {
   var uri = url('http://', this.options.gateway, '/api/monitoring/status');
-  utilities.contactRouter(uri, token, function(error, response) {
+  utilities.contactRouter(uri, token, null, function(error, response) {
     callback(error, response);
   });
 };
 
 API.getTrafficStatistics = function(token, callback) {
   var uri = url('http://', this.options.gateway, '/api/monitoring/traffic-statistics');
-  utilities.contactRouter(uri, token, function(error, response) {
+  utilities.contactRouter(uri, token, null, function(error, response) {
     callback(error, response);
   });
 };
 
 API.getBasicSettings = function(token, callback) {
   var uri = url('http://', this.options.gateway, '/api/wlan/basic-settings');
-  utilities.contactRouter(uri, token, function(error, response) {
+  utilities.contactRouter(uri, token, null, function(error, response) {
     callback(error, response);
   });
 };
 
 API.getCurrentPLMN = function(token, callback) {
   var uri = url('http://', this.options.gateway, '/api/net/current-plmn');
-  utilities.contactRouter(uri, token, function(error, response) {
+  utilities.contactRouter(uri, token, null, function(error, response) {
     callback(error, response);
   });
 };
 
 API.getToken = function(callback) {
   var uri = url('http://', this.options.gateway, '/api/webserver/SesTokInfo');
-  utilities.contactRouter(uri, {}, function(error, response) {
+  utilities.contactRouter(uri, {}, null, function(error, response) {
     callback(error, {
       cookies: response.SesInfo[0],
       token: response.TokInfo[0]

--- a/lib/router.js
+++ b/lib/router.js
@@ -65,6 +65,45 @@ API.getToken = function(callback) {
   });
 };
 
+API.getLedStatus = function(token, callback) {
+  var uri = url('http://', this.options.gateway, '/api/led/circle-switch');
+  utilities.contactRouter(uri, token, null, function(error, response) {
+    callback(error, response);
+  });
+};
+
+API.setLedOn = function(token, value, callback) {
+  var uri = url('http://', this.options.gateway, '/api/led/circle-switch');
+  var body = {
+    ledSwitch: value ? 1 : 0
+  };
+  body = `<?xml version:"1.0" encoding="UTF-8"?><request><ledSwitch>${value?'1':'0'}</ledSwitch></request>`
+  utilities.contactRouter(uri, token, body, function(error, response) {
+    callback(error, response);
+  });
+};
+
+API.isLoggedIn = function(token, callback) {
+  var uri = url('http://', this.options.gateway, '/api/user/state-login');
+  utilities.contactRouter(uri, token, null, function(error, response) {
+    callback(error, response);
+  });
+};
+
+API.login = function(token, username, password, callback) {
+  var uri = url('http://', this.options.gateway, '/api/user/login');
+  var body = {
+    Username: username,
+    password_type: 4,
+    Password: utilities.SHA256andBase64(
+      username + utilities.SHA256andBase64(password) + token.token
+    )
+  };
+  utilities.contactRouter(uri, token, body, function(error, response) {
+    callback(error, response);
+  });
+}
+
 function create(options) {
   return new HuaweiRouter(options);
 }

--- a/lib/router.js
+++ b/lib/router.js
@@ -4,7 +4,7 @@ require('default');
 
 function DailogRouter(options) {
   this.options = {
-    gateway: '192.168.8.1'
+    gateway: process.env.HUAWEI_GW_IP || '192.168.8.1'
   };
   this.options = this.options.default(options);
 }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -6,10 +6,6 @@ var request = require('request');
 var utilities = module.exports;
 
 utilities.contactRouter = function(uri, token, callback) {
-  if(typeof(token) === 'function'){
-    callback = token;
-    token = {};
-  }
   var options = {
     url: uri,
     headers: {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -19,6 +19,7 @@ var errorCodes = {
   "125002": "Bad request, generic", // ??
   "125003": "Session tokens missing", // ??
   "100008": "Unknown", // ??
+  "108006": "Wrong password", // ??
 };
 
 utilities.contactRouter = function(uri, token, post, callback) {
@@ -88,10 +89,10 @@ utilities.prepareLogin = function(username, password, token) {
   return js2xml.buildObject(login);
 };
 
-var SHA256andBase64 = function(text) {
+utilities.SHA256andBase64 = function(text) {
   return new Buffer(
     crypto.createHash('sha256')
     .update(text)
-    .digest("hex")
-  ).toString('base64');
+    .digest('hex'),
+  'utf-8').toString('base64');
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -5,20 +5,53 @@ var request = require('request');
 
 var utilities = module.exports;
 
-utilities.contactRouter = function(uri, token, callback) {
+// Error code names from here: https://github.com/MartijnBraam/huawei-3g/blob/master/huawei_3g/huawei_e303.py
+var errorCodes = {
+  "100002": "No support", // Huawei branded 404
+  "100003": "Access denied", // Huawei branded 403
+  "100004": "Busy",
+  "108001": "Wrong username",
+  "108002": "Wrong password",
+  "108003": "Already logged in",
+  "120001": "Voice busy",
+  "125001": "Wrong __RequestVerificationToken header",
+
+  "125002": "Bad request, generic", // ??
+  "125003": "Session tokens missing", // ??
+  "100008": "Unknown", // ??
+};
+
+utilities.contactRouter = function(uri, token, post, callback) {
   var options = {
     url: uri,
     headers: {
-      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.109 Safari/537.36',
       'Cookie': token.cookies,
       '__RequestVerificationToken': token.token,
       'DNT': '1'
     }
   };
+  if (post) {
+    options.method = 'POST';
+
+    if (typeof post === "object") options.form = js2xml.buildObject({request:post});
+    else options.form = post;
+  }
+
   request(options, function(error, response, body) {
     if (error) callback(error, null);
+
+    if (response.headers['set-cookie']) token.cookies = response.headers['set-cookie'][0].split(';')[0];
+    if (response.headers['__requestverificationtoken']) token.token = response.headers['__requestverificationtoken'];
+    // if (response.headers['__requestverificationtokenone']) token.tokenOne = response.headers['__requestverificationtokenone']
+    // if (response.headers['__requestverificationtokentwo']) token.tokenTwo = response.headers['__requestverificationtokentwo']
+
     xml2js.parseString(body, function(error, response) {
-      callback(error, response.response);
+      if (response.error) {
+        if (errorCodes[response.error.code]) callback(errorCodes[response.error.code]);
+        else callback(new Error(response.error.code + ': ' + response.error.message));
+      } else {
+        callback(error, response.response);
+      }
     });
   });
 };

--- a/tests/index.js
+++ b/tests/index.js
@@ -82,3 +82,16 @@ describe('getBasicSettings', function() {
     });
   });
 });
+
+describe('login', function() {
+  it('should login correctly to the router', function(done) {
+    var router = new Router();
+    router.getToken(function(error, token) {
+      router.login(token, 'admin', process.env.HUAWEI_GW_PASSWORD, function(error, response) {
+        expect(error).to.not.exist;
+        expect(response).to.equal('OK');
+        done();
+      });
+    });
+  });
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -2,75 +2,82 @@ var expect = require('chai').expect;
 var Router = require('../lib/router');
 
 describe('getToken', function() {
-  it('should provide a token for the other functions to authenticate with ', function() {
+  it('should provide a token for the other functions to authenticate with ', function(done) {
     var router = new Router();
     router.getToken(function(error, token) {
       expect(token).to.have.property('token');
+      done();
     });
   });
 });
 
 describe('getMonthStatistics', function() {
-  it('should respond with the monthly data statistics/quota set on the router ', function() {
+  it('should respond with the monthly data statistics/quota set on the router ', function(done) {
     var router = new Router();
-    router.getToken(function(token) {
+    router.getToken(function(error, token) {
       router.getMonthStatistics(token, function(error, response) {
         expect(response).to.have.property('CurrentMonthDownload');
+        done();
       });
     });
   });
 });
 
 describe('getSignal', function() {
-  it('should respond with the signal information on the router ', function() {
+  it('should respond with the signal information on the router ', function(done) {
     var router = new Router();
-    router.getToken(function(token) {
-      router.getMonthStatistics(token, function(error, response) {
+    router.getToken(function(error, token) {
+      router.getSignal(token, function(error, response) {
         expect(response).to.have.property('cell_id');
+        done();
       });
     });
   });
 });
 
 describe('getStatus', function() {
-  it('should respond with the status information on the router ', function() {
+  it('should respond with the status information on the router ', function(done) {
     var router = new Router();
-    router.getToken(function(token) {
+    router.getToken(function(error, token) {
       router.getStatus(token, function(error, response) {
         expect(response).to.have.property('ConnectionStatus');
+        done();
       });
     });
   });
 });
 
 describe('getTrafficStatistics', function() {
-  it('should respond with the traffic transferred', function() {
+  it('should respond with the traffic transferred', function(done) {
     var router = new Router();
-    router.getToken(function(token) {
+    router.getToken(function(error, token) {
       router.getTrafficStatistics(token, function(error, response) {
         expect(response).to.have.property('CurrentConnectTime');
+        done();
       });
     });
   });
 });
 
 describe('getCurrentPLMN', function() {
-  it('should with the Public Land Mobile Network Information', function() {
+  it('should with the Public Land Mobile Network Information', function(done) {
     var router = new Router();
-    router.getToken(function(token) {
+    router.getToken(function(error, token) {
       router.getCurrentPLMN(token, function(error, response) {
         expect(response).to.have.property('FullName');
+        done();
       });
     });
   });
 });
 
 describe('getBasicSettings', function() {
-  it('should respond with the signal information on the router ', function() {
+  it('should respond with the signal information on the router ', function(done) {
     var router = new Router();
-    router.getToken(function(token) {
-      router.getMonthStatistics(token, function(error, response) {
+    router.getToken(function(error, token) {
+      router.getBasicSettings(token, function(error, response) {
         expect(response).to.have.property('WifiSsid');
+        done();
       });
     });
   });


### PR DESCRIPTION
Hey,

Nice library, good work!

I need to access my Huawei B315 and it has the exact same API as your Dialog device, and the internet seems to agree that other Huawei routers share it as well. Which of course does make sense.

I used your original sources of information and some time to get the login work correctly. So now it is possible to extend the library to do all the operations that are behind login (which of course is most of it).

What do you think? Worth a pull?

Also I would love for you to rename the npm package (and the repository) to something like huawei-router-api or similar, as my device is not Dialog branded and it might push others off as well.


Cheers,

Rolf
