### PR TITLE
Add /api/wlan/host-list endpoint

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -13,6 +13,13 @@ var API = HuaweiRouter.prototype;
 module.exports = HuaweiRouter;
 module.exports.create = create;
 
+API.getHostList = function(token, callback) {
+  var uri = url('http://', this.options.gateway, '/api/wlan/host-list');
+  utilities.contactRouter(uri, token, null, function(error, response) {
+    callback(error, response);
+  });
+};
+
 API.getMonthStatistics = function(token, callback) {
   var uri = url('http://', this.options.gateway, '/api/monitoring/month_statistics');
   utilities.contactRouter(uri, token, null, function(error, response) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "xml2js": "^0.4.16"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
     "mocha": "^3.2.0",
     "should": "^11.1.2"
   },

--- a/tests/index.js
+++ b/tests/index.js
@@ -35,6 +35,18 @@ describe('getSignal', function() {
   });
 });
 
+describe('getHostList', function() {
+  it('should respond with the host-list information on the router ', function(done) {
+    var router = new Router();
+    router.getToken(function(error, token) {
+      router.getHostList(token, function(error, response) {
+        expect(response).to.have.property('Hosts');
+        done();
+      });
+    });
+  });
+});
+
 describe('getStatus', function() {
   it('should respond with the status information on the router ', function(done) {
     var router = new Router();


### PR DESCRIPTION
Hi,

* Add getHostList method in router.js.
* Add chai in devDependencies to run tests.

/api/wlan/host-list endpoint returns something like this.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<response>
    <Hosts>
        <Host>
            <ID>1</ID>
           <MacAddress>A8:BB:CF:DA:E1:40</MacAddress>
           <IpAddress>192.168.1.11</IpAddress>
           <HostName>Mobile-Phone</HostName> 
           <AssociatedTime>46222</AssociatedTime>
           <AssociatedSsid>WIFI_ACCESS</AssociatedSsid>
        </Host>
        <Host>
            <ID>2</ID>
           <MacAddress>F8:1E:DF:2F:B8:35</MacAddress>
           <IpAddress>192.168.1.199</IpAddress>
           <HostName>Computer</HostName>
           <AssociatedTime>11535</AssociatedTime>
           <AssociatedSsid>WIFI_ACCESS</AssociatedSsid>
        </Host>
    </Hosts>
</response>
```